### PR TITLE
Fix small typos and add link to a11y article

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,10 @@
       color: #f2fdff;
     }
 
+    a {
+      color: white;
+    }
+
     h1 {
       text-align: center;
       margin: 0;
@@ -48,7 +52,6 @@
     }
 
     footer a {
-      color: white;
       display: flex;
       align-items: center;
       margin-bottom: 50px;
@@ -65,7 +68,7 @@
       <p>
         For the love of God, do not do this to me, man. <br />Custom <code>select</code>s are a
         pain for everyone involved.<br />
-        They are not accessible, and most of the time make for a way worse UI.
+        They are <a href="https://www.webaxe.org/accessible-custom-select-dropdowns/">not accessible</a>, and most of the time make for a way worse UI.
         <br />No one cares about styled <code>option</code> tags, I promise you.
       </p>
     </main>

--- a/index.html
+++ b/index.html
@@ -63,10 +63,10 @@
     <main>
       <h1>NO!</h1>
       <p>
-        For the love of god do not do this to me man. <br />Custom selects are a
+        For the love of god, do not do this to me, man. <br />Custom selects are a
         pain for everyone involved.<br />
-        They are not acessible and most of the times make a way worst UI.
-        <br />No one cares about styled option tags I promise you
+        They are not accessible, and most of the time make for a way worse UI.
+        <br />No one cares about styled option tags, I promise you.
       </p>
     </main>
     <footer>

--- a/index.html
+++ b/index.html
@@ -63,10 +63,10 @@
     <main>
       <h1>NO!</h1>
       <p>
-        For the love of god, do not do this to me, man. <br />Custom selects are a
+        For the love of god, do not do this to me, man. <br />Custom <code>select</code>s are a
         pain for everyone involved.<br />
         They are not accessible, and most of the time make for a way worse UI.
-        <br />No one cares about styled option tags, I promise you.
+        <br />No one cares about styled <code>option</code> tags, I promise you.
       </p>
     </main>
     <footer>

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
     <main>
       <h1>NO!</h1>
       <p>
-        For the love of god, do not do this to me, man. <br />Custom <code>select</code>s are a
+        For the love of God, do not do this to me, man. <br />Custom <code>select</code>s are a
         pain for everyone involved.<br />
         They are not accessible, and most of the time make for a way worse UI.
         <br />No one cares about styled <code>option</code> tags, I promise you.


### PR DESCRIPTION
This PR:
- Fixes some small typos, as discussed on Twitter
- Adds the `<code />`  tag around `select` and `option`
- Adds a link to an [article](webaxe.org/accessible-custom-select-dropdowns/) that explains why custom selects are bad for a11y